### PR TITLE
Properly reset when calling srand for Philox2x

### DIFF
--- a/src/Random123/philox.jl
+++ b/src/Random123/philox.jl
@@ -64,6 +64,7 @@ function srand{T<:Union{UInt32, UInt64}}(r::Philox2x{T}, seed::Integer=gen_seed(
     r.key = seed % T
     r.ctr1 = r.ctr2 = 0
     random123_r(r)
+    r.p = 0
     r
 end
 


### PR DESCRIPTION
Setting `r.p = 0` ensures sequence always starts identically after `srand()`