### PR TITLE
Allow build() to run on Windows

### DIFF
--- a/deps/Random123/build.jl
+++ b/deps/Random123/build.jl
@@ -35,7 +35,7 @@ end
 
 check_compiler() = is_windows() ? true : success(`gcc --version`)
 
-if have_aesni() && check_compiler()
+if have_aesni() && check_compiler() && false
     build()
 else
     warn("AES-NI will not be compiled.")

--- a/deps/Random123/build.jl
+++ b/deps/Random123/build.jl
@@ -10,7 +10,7 @@ function build()
             else
                 url = "https://github.com/sunoru/RandomNumbers.jl/releases/download/deplib-0.1/librandom123.dll"
             end
-            info("You don't have MinGW32 installed, so now download the library binary from github.")
+            info("You don't have MinGW32 installed, so now downloading the library binary from github.")
             download(url, "librandom123.dll")
         end
     else
@@ -33,7 +33,7 @@ function have_aesni()
     end
 end
 
-check_compiler() = success(`gcc --version`)
+check_compiler() = is_windows() ? true : success(`gcc --version`)
 
 if have_aesni() && check_compiler()
     build()

--- a/deps/Random123/build.jl
+++ b/deps/Random123/build.jl
@@ -35,7 +35,7 @@ end
 
 check_compiler() = is_windows() ? true : success(`gcc --version`)
 
-if have_aesni() && check_compiler() && false
+if have_aesni() && check_compiler()
     build()
 else
     warn("AES-NI will not be compiled.")


### PR DESCRIPTION
Issue #19 

On Windows, `check_compiler()` now returns true regardless of whether `gcc` is installed.
This allows `build()` to run.

Also changed info message from "...download..." (which sounds like an instruction to the user to manually download), to "...downloading..." (which suggests the build process is doing this for the user)