### PR TITLE
build: using gmake for FreeBSD

### DIFF
--- a/deps/Random123/build.jl
+++ b/deps/Random123/build.jl
@@ -13,6 +13,8 @@ function build()
             info("You don't have MinGW32 installed, so now downloading the library binary from github.")
             download(url, "librandom123.dll")
         end
+    elseif is_bsd() && !is_apple()  # e.g. FreeBSD
+        run(`gmake`)
     else
         run(`make`)
     end


### PR DESCRIPTION
The implementation of `make` on FreeBSD is `bmake` by default.
But the `Makefile` in this repo is using `GNU make` syntax which is incompatable with `bmake`.
To invoking `GNU make` on FreeBSD, just use `gmake`.