### PR TITLE
1.0 fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,13 @@ author = ["Sunoru <s@sunoru.com>"]
 repo = "https://github.com/sunoru/RandomNumbers.jl.git"
 version = "0.2.0"
 
+
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - SET PATH=C:\MinGW\bin;%PATH%
-  - C:\projects\julia\bin\julia -e "versioninfo(); import Pkg;
+  - C:\projects\julia\bin\julia -e "using InteractiveUtils; versioninfo(); import Pkg;
       Pkg.clone(pwd(), \"RandomNumbers\"); Pkg.build(\"RandomNumbers\")"
 
 test_script:

--- a/deps/Random123/build.jl
+++ b/deps/Random123/build.jl
@@ -13,7 +13,7 @@ function build()
             info("You don't have MinGW32 installed, so now downloading the library binary from github.")
             download(url, "librandom123.dll")
         end
-    elseif is_bsd() && !is_apple()  # e.g. FreeBSD
+    elseif Sys.isbsd() && !Sys.isapple()  # e.g. FreeBSD
         run(`gmake`)
     else
         run(`make`)

--- a/docs/src/lib/random-numbers.md
+++ b/docs/src/lib/random-numbers.md
@@ -14,7 +14,7 @@ Pages = ["random-numbers.md"]
 ## [Generic Functions](@id generic-functions)
 ```@docs
 rand
-srand
+seed!
 randn
 randexp
 bitrand

--- a/docs/src/man/basics.md
+++ b/docs/src/man/basics.md
@@ -50,7 +50,7 @@ as `UInt64`, `UInt32`, etc. Users can change the output type of a certain RNG ty
 
 Consistent to what `Base.Random` does, there are generic functions:
 
-- `srand(::AbstractRNG{T}[, seed])`
+- `seed!(::AbstractRNG{T}[, seed])`
     initializes a RNG by one or a sequence of numbers (called *seed*). The output sequences by two RNGs of
     the same type should be the same if they are initialized by the same seed, which makes them
     *deterministic*. The seed type of each RNG type can be different, you can refer to the corresponding
@@ -69,7 +69,7 @@ such as `randn`, `randexp`, `randcycle`, etc. defined in `Base.Random` still wor
 [official docs](http://docs.julialang.org/en/release-0.5/stdlib/numbers/#random-numbers) don't include all of
 them, so you can refer to [this section](@ref generic-functions) for details.
 
-The constructors of all the types of RNG are designed to take the same kind of parameters as `srand`. For example:
+The constructors of all the types of RNG are designed to take the same kind of parameters as `seed!`. For example:
 
 ```jldoctest
 julia> using RandomNumbers.Xorshifts

--- a/docs/src/man/mersenne-twisters.md
+++ b/docs/src/man/mersenne-twisters.md
@@ -61,7 +61,7 @@ someone needs the reproducibility, just save the state `r.mt` and use it for nex
 An initialization function described in the original paper[^1] is also implemented here, so the seed can also
 be just one `UInt32` number (or an `Integer` whose least 32 bits will be truncated):
 ```jldoctest
-julia> srand(r, 0xabcdef12);
+julia> seed!(r, 0xabcdef12);
 
 julia> rand(r, UInt32, 10)
 10-element Array{UInt32,1}:

--- a/docs/src/man/pcg.md
+++ b/docs/src/man/pcg.md
@@ -77,7 +77,7 @@ julia> [bounded_rand(r, UInt64(100)) for i in 1:6]
 
 PCG also has an [`advance!`](@ref) function, used to advance the state of a PCG instance.
 ```jldoctest
-julia> srand(r, 1234567);
+julia> seed!(r, 1234567);
 
 julia> rand(r, 4)
 4-element Array{Float64,1}:

--- a/src/MersenneTwisters/bases.jl
+++ b/src/MersenneTwisters/bases.jl
@@ -31,8 +31,8 @@ mutable struct MT19937 <: MersenneTwister{UInt32}
         new(x, i)
     end
 end
-MT19937(seed::Integer) = srand(MT19937(Vector{UInt32}(undef, N), 1), seed % UInt32)
-MT19937(seed::NTuple{N, UInt32}=gen_seed(UInt32, N)) = srand(MT19937(Vector{UInt32}(undef, N), 1), seed)
+MT19937(seed::Integer) = seed!(MT19937(Vector{UInt32}(undef, N), 1), seed % UInt32)
+MT19937(seed::NTuple{N, UInt32}=gen_seed(UInt32, N)) = seed!(MT19937(Vector{UInt32}(undef, N), 1), seed)
 
 "Set up a `MT19937` RNG object using a `Tuple` of $N `UInt32` numbers."
 @inline function mt_set!(r::MT19937, s::NTuple{N, UInt32})

--- a/src/MersenneTwisters/main.jl
+++ b/src/MersenneTwisters/main.jl
@@ -1,11 +1,11 @@
 import Base: copy, copyto!, ==
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: gen_seed, seed_type
 
 @inline rand(r::MT19937, ::Type{UInt32}) = mt_get(r)
 
-srand(r::MT19937, seed::Integer) = mt_set!(r, seed % UInt32)
-srand(r::MT19937, seed::NTuple{N, UInt32}=gen_seed(UInt32, N)) = mt_set!(r, seed)
+seed!(r::MT19937, seed::Integer) = mt_set!(r, seed % UInt32)
+seed!(r::MT19937, seed::NTuple{N, UInt32}=gen_seed(UInt32, N)) = mt_set!(r, seed)
 
 seed_type(::Type{MT19937}) = NTuple{N, UInt32}
 

--- a/src/PCG/bases.jl
+++ b/src/PCG/bases.jl
@@ -163,7 +163,7 @@ end
     ((high_bits % T) << spare_bits) ⊻ (low_bits % T)
 end
 
-# PCGState types, seed!om and Step functions.
+# PCGState types, SRandom and Step functions.
 """
 ```julia
 AbstractPCG{StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} <: AbstractRNG{OutputType}

--- a/src/PCG/bases.jl
+++ b/src/PCG/bases.jl
@@ -163,7 +163,7 @@ end
     ((high_bits % T) << spare_bits) ⊻ (low_bits % T)
 end
 
-# PCGState types, SRandom and Step functions.
+# PCGState types, seed!om and Step functions.
 """
 ```julia
 AbstractPCG{StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} <: AbstractRNG{OutputType}
@@ -183,7 +183,7 @@ mutable struct PCGStateOneseq{StateType<:PCGUInt, MethodType<:PCGMethod, OutputT
         {StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} = new()
 end
 
-@inline function pcg_srand(s::PCGStateOneseq{T}, init_state::T) where T <: PCGUInt
+@inline function pcg_seed!(s::PCGStateOneseq{T}, init_state::T) where T <: PCGUInt
     s.state = 0 % T
     pcg_step!(s)
     s.state += init_state
@@ -212,7 +212,7 @@ mutable struct PCGStateMCG{StateType<:PCGUInt, MethodType<:PCGMethod, OutputType
         {StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} = new()
 end
 
-@inline function pcg_srand(s::PCGStateMCG{T}, init_state::T) where T <: PCGUInt
+@inline function pcg_seed!(s::PCGStateMCG{T}, init_state::T) where T <: PCGUInt
     s.state = init_state | 1
     s
 end
@@ -238,7 +238,7 @@ mutable struct PCGStateUnique{StateType<:PCGUInt, MethodType<:PCGMethod, OutputT
         {StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} = new()
 end
 
-@inline function pcg_srand(s::PCGStateUnique{T}, init_state::T) where T <: PCGUInt
+@inline function pcg_seed!(s::PCGStateUnique{T}, init_state::T) where T <: PCGUInt
     s.state = 0 % T
     pcg_step!(s)
     s.state += init_state
@@ -269,7 +269,7 @@ mutable struct PCGStateSetseq{StateType<:PCGUInt, MethodType<:PCGMethod, OutputT
         {StateType<:PCGUInt, MethodType<:PCGMethod, OutputType<:PCGUInt} = new()
 end
 
-@inline function pcg_srand(s::PCGStateSetseq{T}, init_state::T, init_seq::T) where T <: PCGUInt
+@inline function pcg_seed!(s::PCGStateSetseq{T}, init_state::T, init_seq::T) where T <: PCGUInt
     s.state = 0
     s.inc = (init_seq << 1) | 1
     pcg_step!(s)
@@ -294,7 +294,7 @@ end
 pcg_output
 
 "Initialize a PCG object."
-pcg_srand
+pcg_seed!
 
 "Do one iteration step for a PCG object."
 pcg_step!

--- a/src/PCG/main.jl
+++ b/src/PCG/main.jl
@@ -1,13 +1,13 @@
 import Base: copy, copyto!, ==
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: gen_seed, seed_type
 
 # Generic functions
 
-@inline srand(r::AbstractPCG{StateType}, seed::Integer=gen_seed(StateType)) where
-    StateType <: PCGUInt = pcg_srand(r, seed % StateType)
-@inline srand(r::PCGStateSetseq{StateType}, seed::NTuple{2, Integer}=gen_seed(StateType, 2)) where
-    StateType <: PCGUInt = pcg_srand(r, seed[1] % StateType, seed[2] % StateType)
+@inline seed!(r::AbstractPCG{StateType}, seed::Integer=gen_seed(StateType)) where
+    StateType <: PCGUInt = pcg_seed!(r, seed % StateType)
+@inline seed!(r::PCGStateSetseq{StateType}, seed::NTuple{2, Integer}=gen_seed(StateType, 2)) where
+    StateType <: PCGUInt = pcg_seed!(r, seed[1] % StateType, seed[2] % StateType)
 
 @inline seed_type(::Type{PCGStateOneseq{T, T1, T2}}) where {T, T1, T2} = T
 @inline seed_type(::Type{PCGStateMCG{   T, T1, T2}}) where {T, T1, T2} = T
@@ -103,14 +103,14 @@ for (pcg_type_t, uint_type, method_symbol, output_type) in PCG_LIST
         @eval function $pcg_type(output_type::Type{$output_type}, method::Type{$method},
                 seed::Integer=gen_seed($uint_type))
             s = $pcg_type{$uint_type, method, output_type}()
-            srand(s, seed)
+            seed!(s, seed)
             s
         end
     else
         @eval function $pcg_type(output_type::Type{$output_type}, method::Type{$method},
                 seed::NTuple{2, Integer}=gen_seed($uint_type, 2))
             s = $pcg_type{$uint_type, method, output_type}()
-            srand(s, seed)
+            seed!(s, seed)
             s
         end
     end

--- a/src/Random123/aesni.jl
+++ b/src/Random123/aesni.jl
@@ -42,12 +42,12 @@ mutable struct AESNI1x <: R123Generator1x{UInt128}
     function AESNI1x(seed::Integer=gen_seed(UInt128))
         @warn "`AESNI1x` would be unstable on Windows platform in this version, please use other RNGs."
         r = new(0, 0, AESNIKey())
-        srand(r, seed)
+        seed!(r, seed)
         r
     end
 end
 
-function srand(r::AESNI1x, seed::Integer=gen_seed(UInt128))
+function seed!(r::AESNI1x, seed::Integer=gen_seed(UInt128))
     initkey(r, seed % UInt128)
     r.ctr = 0
     random123_r(r)
@@ -90,12 +90,12 @@ mutable struct AESNI4x <: R123Generator4x{UInt32}
     function AESNI4x(seed::NTuple{4, Integer}=gen_seed(UInt32, 4))
         @warn "`AESNI4x` would be unstable on Windows platform in this version, please use other RNGs."
         r = new(0, 0, 0, 0, 0, AESNIKey(), 0)
-        srand(r, seed)
+        seed!(r, seed)
         r
     end
 end
 
-function srand(r::AESNI4x, seed::NTuple{4, Integer}=gen_seed(UInt32, 4))
+function seed!(r::AESNI4x, seed::NTuple{4, Integer}=gen_seed(UInt32, 4))
     key = union_uint(map(x -> x % UInt32, seed))
     initkey(r, key)
     r.ctr1 = 0

--- a/src/Random123/ars.jl
+++ b/src/Random123/ars.jl
@@ -26,10 +26,10 @@ end
 function ARS1x(seed::Integer=gen_seed(UInt128), R::Integer=7)
     @assert 1 <= R <= 10
     r = ARS1x{Int(R)}(0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 
-function srand(r::ARS1x, seed::Integer=gen_seed(UInt128))
+function seed!(r::ARS1x, seed::Integer=gen_seed(UInt128))
     r.key = seed % UInt128
     r.ctr = 0
     random123_r(r)
@@ -88,10 +88,10 @@ end
 function ARS4x(seed::NTuple{4, Integer}=gen_seed(UInt32, 4), R::Integer=7)
     @assert 1 <= R <= 10
     r = ARS4x{Int(R)}(0, 0, 0, 0, 0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 
-function srand(r::ARS4x, seed::NTuple{4, Integer}=gen_seed(UInt32, 4))
+function seed!(r::ARS4x, seed::NTuple{4, Integer}=gen_seed(UInt32, 4))
     r.key = union_uint(map(x -> x % UInt32, seed))
     r.ctr1 = 0
     p = 0

--- a/src/Random123/common.jl
+++ b/src/Random123/common.jl
@@ -1,5 +1,5 @@
 import Libdl
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: AbstractRNG
 
 const librandom123 = Libdl.find_library(["librandom123"], 

--- a/src/Random123/philox.jl
+++ b/src/Random123/philox.jl
@@ -1,5 +1,5 @@
 import Base: copy, copyto!, ==
-import Random: srand
+import Random: seed!
 import RandomNumbers: gen_seed, seed_type, unsafe_copyto!, unsafe_compare
 
 for (w, T, Td) in ((32, UInt32, UInt64), (64, UInt64, UInt128))
@@ -55,11 +55,11 @@ end
 function Philox2x(::Type{T}=UInt64, seed::Integer=gen_seed(T), R::Integer=10) where T <: Union{UInt32, UInt64}
     @assert 1 <= R <= 16
     r = Philox2x{T, Int(R)}(0, 0, 0, 0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 Philox2x(seed::Integer, R::Integer=10) = Philox2x(UInt64, seed, R)
 
-function srand(r::Philox2x{T}, seed::Integer=gen_seed(T)) where T <: Union{UInt32, UInt64}
+function seed!(r::Philox2x{T}, seed::Integer=gen_seed(T)) where T <: Union{UInt32, UInt64}
     r.x1 = r.x2 = 0
     r.key = seed % T
     r.ctr1 = r.ctr2 = 0
@@ -145,11 +145,11 @@ function Philox4x(::Type{T}=UInt64, seed::NTuple{2, Integer}=gen_seed(T, 2), R::
         T <: Union{UInt32, UInt64}
     @assert 1 <= R <= 16
     r = Philox4x{T, Int(R)}(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 Philox4x(seed::NTuple{2, Integer}, R::Integer=10) = Philox4x(UInt64, seed, R)
 
-function srand(r::Philox4x{T}, seed::NTuple{2, Integer}=gen_seed(T, 2)) where T <: Union{UInt32, UInt64}
+function seed!(r::Philox4x{T}, seed::NTuple{2, Integer}=gen_seed(T, 2)) where T <: Union{UInt32, UInt64}
     r.x1 = r.x2 = r.x3 = r.x4 = 0
     r.key1 = seed[1] % T
     r.key2 = seed[2] % T
@@ -251,4 +251,3 @@ end
     end
     r.x1, r.x2, r.x3, r.x4 = ctr1, ctr2, ctr3, ctr4
 end
-

--- a/src/Random123/threefry.jl
+++ b/src/Random123/threefry.jl
@@ -1,5 +1,5 @@
 import Base: copy, copyto!, ==
-import Random: srand
+import Random: seed!
 import RandomNumbers: gen_seed, seed_type, unsafe_copyto!, unsafe_compare
 
 @inline threefry_rotl(x::UInt64, N) = (x << (N & 63)) | (x >> ((64-N) & 63))
@@ -90,11 +90,11 @@ function Threefry2x(::Type{T}=UInt64, seed::NTuple{2, Integer}=gen_seed(T, 2), R
         T <: Union{UInt32, UInt64}
     @assert 1 <= R <= 32
     r = Threefry2x{T, Int(R)}(0, 0, 0, 0, 0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 Threefry2x(seed::NTuple{2, Integer}, R::Integer=20) = Threefry2x(UInt64, seed, R)
 
-function srand(r::Threefry2x{T}, seed::NTuple{2, Integer}=gen_seed(T, 2)) where T <: Union{UInt32, UInt64}
+function seed!(r::Threefry2x{T}, seed::NTuple{2, Integer}=gen_seed(T, 2)) where T <: Union{UInt32, UInt64}
     r.x1 = r.x2 = 0
     r.key1 = seed[1] % T
     r.key2 = seed[2] % T
@@ -231,11 +231,11 @@ function Threefry4x(::Type{T}=UInt64, seed::NTuple{4, Integer}=gen_seed(T, 4), R
         T <: Union{UInt32, UInt64}
     @assert 1 <= R <= 72
     r = Threefry4x{T, Int(R)}(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    srand(r, seed)
+    seed!(r, seed)
 end
 Threefry4x(seed::NTuple{4, Integer}, R::Integer=20) = Threefry4x(UInt64, seed, R)
 
-function srand(r::Threefry4x{T}, seed::NTuple{4, Integer}=gen_seed(T, 4)) where T <: Union{UInt32, UInt64}
+function seed!(r::Threefry4x{T}, seed::NTuple{4, Integer}=gen_seed(T, 4)) where T <: Union{UInt32, UInt64}
     r.x1 = r.x2 = r.x3 = r.x4 = 0
     r.key1, r.key2, r.key3, r.key4 = seed[1] % T, seed[2] % T, seed[3] % T, seed[4] % T
     r.ctr1 = r.ctr2 = r.ctr3 = r.ctr4 = 0

--- a/src/Xorshifts/xoroshiro128.jl
+++ b/src/Xorshifts/xoroshiro128.jl
@@ -1,5 +1,5 @@
 import Base: copy, copyto!, ==
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: AbstractRNG, gen_seed, split_uint, seed_type
 
 """
@@ -25,7 +25,7 @@ for (star, plus) in (
             y::UInt64
             function $rng_name(seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
                 r = new(0, 0)
-                srand(r, seed)
+                seed!(r, seed)
                 r
             end
         end
@@ -55,8 +55,8 @@ copy(src::T) where T <: AbstractXoroshiro128 = copyto!(T(), src)
 
 ==(r1::T, r2::T) where T <: AbstractXoroshiro128 = r1.x == r2.x && r1.y == r2.y
 
-srand(r::AbstractXoroshiro128, seed::Integer) = srand(r, split_uint(seed % UInt128))
-function srand(r::AbstractXoroshiro128, seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
+seed!(r::AbstractXoroshiro128, seed::Integer) = seed!(r, split_uint(seed % UInt128))
+function seed!(r::AbstractXoroshiro128, seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
     r.x = seed[1]
     r.y = seed[2]
     xorshift_next(r)

--- a/src/Xorshifts/xorshift128.jl
+++ b/src/Xorshifts/xorshift128.jl
@@ -1,5 +1,5 @@
 import Base: copy, copyto!, ==
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: AbstractRNG, gen_seed, split_uint, seed_type
 
 """
@@ -23,7 +23,7 @@ for (star, plus) in (
             y::UInt64
             function $rng_name(seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
                 r = new(0, 0)
-                srand(r, seed)
+                seed!(r, seed)
                 r
             end
         end
@@ -52,9 +52,9 @@ copy(src::T) where T <: AbstractXorshift128 = copyto!(T(), src)
 
 ==(r1::T, r2::T) where T <: AbstractXorshift128 = r1.x == r2.x && r1.y == r2.y
 
-srand(r::AbstractXorshift128, seed::Integer) = srand(r, split_uint(seed % UInt128))
+seed!(r::AbstractXorshift128, seed::Integer) = seed!(r, split_uint(seed % UInt128))
 
-function srand(r::AbstractXorshift128, seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
+function seed!(r::AbstractXorshift128, seed::NTuple{2, UInt64}=gen_seed(UInt64, 2))
     r.x = seed[1]
     r.y = seed[2]
     xorshift_next(r)

--- a/src/Xorshifts/xorshift64.jl
+++ b/src/Xorshifts/xorshift64.jl
@@ -1,5 +1,5 @@
 import Base: copy, copyto!, ==
-import Random: rand, srand
+import Random: rand, seed!
 import RandomNumbers: AbstractRNG, gen_seed, seed_type
 
 """
@@ -18,7 +18,7 @@ for star in (false, true)
             x::UInt64
             function $rng_name(seed::UInt64=gen_seed(UInt64))
                 r = new(0)
-                srand(r, seed)
+                seed!(r, seed)
                 r
             end
         end
@@ -45,7 +45,7 @@ copy(src::T) where T <: AbstractXorshift64 = copyto!(T(), src)
 
 ==(r1::T, r2::T) where T <: AbstractXorshift64 = r1.x == r2.x
 
-function srand(r::AbstractXorshift64, seed::Integer=gen_seed(UInt64))
+function seed!(r::AbstractXorshift64, seed::Integer=gen_seed(UInt64))
     r.x = seed % UInt64
     xorshift_next(r)
     r

--- a/src/wrapped_rng.jl
+++ b/src/wrapped_rng.jl
@@ -76,8 +76,8 @@ end
 
 ==(r1::R, r2::R) where R <: WrappedRNG = r1.base_rng == r2.base_rng && r1.x == r2.x && r1.p == r2.p
 
-function srand(wr::WrappedRNG, seed...)
-    srand(wr.base_rng, seed...)
+function seed!(wr::WrappedRNG, seed...)
+    seed!(wr.base_rng, seed...)
         if sizeof(T1) > sizeof(T2)
             wr.x = rand(wr.base_rng, T1)
         end

--- a/test/Xorshifts/runtests.jl
+++ b/test/Xorshifts/runtests.jl
@@ -36,7 +36,7 @@ for (rng_name, seed_t) in (
     redirect_stdout(outfile)
 
     @eval x = $rng_name()
-    srand(x)
+    seed!(x)
     @test seed_type(x) == seed_t
     @test copyto!(copy(x), x) == x
     if seed_t <: Tuple

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,5 +1,5 @@
 using RandomNumbers
-import Random: srand
+import Random: seed!
 using Test: @test
 using Printf: @printf
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,7 +1,7 @@
 using RandomNumbers
 import Random: seed!
 using Test: @test
-using Printf: @printf
+using Base.Printf: @printf
 
 function compare_dirs(dir1::AbstractString, dir2::AbstractString)
     files1 = readdir(dir1)


### PR DESCRIPTION
is_bsd no longer exists on 1.0, despite not having a depwarn. Replaced with `Sys.isbsd()`. Likewise for `is_apple`.