### PR TITLE
Added efficient bit rotate functions

### DIFF
--- a/src/Xorshifts/common.jl
+++ b/src/Xorshifts/common.jl
@@ -1,5 +1,5 @@
-@inline xorshift_rotl(x::UInt64, k) = (x << k) | (x >> (64 - k))
-@inline xorshift_rotl(x::UInt32, k) = (x << k) | (x >> (32 - k))
+@inline xorshift_rotl(x::UInt64, k::Int) = (x >>> (0x3f & -k)) | (x << (0x3f & k))
+@inline xorshift_rotl(x::UInt32, k::Int) = (x >>> (0x1f & -k)) | (x << (0x1f & k))
 
 """
 SplitMix64: only for initializing a random seed.


### PR DESCRIPTION
Changed the implementation of the `xorshift_rotl` methods. They now compile to something closer to a single bit rotate CPU instruction.